### PR TITLE
SOLR-10046: three changes as follows:

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/OneMergeWrappingMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/OneMergeWrappingMergePolicy.java
@@ -18,17 +18,19 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
+/**
+ * A wrapping merge policy that wraps the {@link org.apache.lucene.index.MergePolicy.OneMerge}
+ * objects returned by the wrapped merge policy.
+ *
+ * @lucene.experimental
+ */
 public class OneMergeWrappingMergePolicy extends MergePolicyWrapper {
-  
-  @FunctionalInterface
-  public interface WrapOneMerge {
-    public OneMerge wrap(OneMerge merge);
-  }
-  
-  private final WrapOneMerge wrapOneMerge;
 
-  public OneMergeWrappingMergePolicy(MergePolicy in, WrapOneMerge wrapOneMerge) {
+  private final UnaryOperator<OneMerge> wrapOneMerge;
+
+  public OneMergeWrappingMergePolicy(MergePolicy in, UnaryOperator<OneMerge> wrapOneMerge) {
     super(in);
     
     this.wrapOneMerge = wrapOneMerge;
@@ -57,7 +59,7 @@ public class OneMergeWrappingMergePolicy extends MergePolicyWrapper {
     MergeSpecification wrapped = spec == null ? null : new MergeSpecification();
     if (wrapped != null) {      
       for (OneMerge merge : spec.merges) {
-        wrapped.add(wrapOneMerge.wrap(merge));
+        wrapped.add(wrapOneMerge.apply(merge));
       }
     }
     return wrapped;

--- a/lucene/core/src/test/org/apache/lucene/index/TestOneMergeWrappingMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestOneMergeWrappingMergePolicy.java
@@ -17,88 +17,130 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
-import org.apache.lucene.analysis.MockAnalyzer;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.index.MergePolicy.OneMerge;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.TestUtil;
+import org.apache.lucene.util.Version;
+import org.junit.Test;
 
-public class TestOneMergeWrappingMergePolicy extends BaseMergePolicyTestCase {
+public class TestOneMergeWrappingMergePolicy extends LuceneTestCase {
 
-  public MergePolicy mergePolicy() {
-    return new OneMergeWrappingMergePolicy(newMergePolicy(random()), this::wrapOneMerge);
-  }
+  private static class PredeterminedMergePolicy extends MergePolicy {
 
-  public OneMerge wrapOneMerge(OneMerge merge) {
-    return new WrappedOneMerge(merge.segments);
-  }
+    final private MergePolicy.MergeSpecification merges;
+    final private MergePolicy.MergeSpecification forcedMerges;
+    final private MergePolicy.MergeSpecification forcedDeletesMerges;
 
-  private static class WrappedOneMerge extends OneMerge {
+    public PredeterminedMergePolicy(
+        MergePolicy.MergeSpecification merges,
+        MergePolicy.MergeSpecification forcedMerges,
+        MergePolicy.MergeSpecification forcedDeletesMerges) {
+      this.merges = merges;
+      this.forcedMerges = forcedMerges;
+      this.forcedDeletesMerges = forcedDeletesMerges;
+    }
 
-    public WrappedOneMerge(List<SegmentCommitInfo> segments) {
-      super(segments);
+    @Override
+    public MergePolicy.MergeSpecification findMerges(MergeTrigger mergeTrigger, SegmentInfos segmentInfos, IndexWriter writer)
+        throws IOException {
+      return merges;
+    }
+
+    @Override
+    public MergePolicy.MergeSpecification findForcedMerges(SegmentInfos segmentInfos, int maxSegmentCount,
+        Map<SegmentCommitInfo,Boolean> segmentsToMerge, IndexWriter writer) throws IOException {
+      return forcedMerges;
+    }
+
+    @Override
+    public MergePolicy.MergeSpecification findForcedDeletesMerges(SegmentInfos segmentInfos, IndexWriter writer)
+        throws IOException {
+      return forcedDeletesMerges;
     }
 
   }
 
-  public void testTestSegmentsAreWrapped() throws Exception {
-    try (Directory dir = newDirectory()) {
-      final MergeScheduler mergeScheduler = new SerialMergeScheduler() {
-        @Override
-        synchronized public void merge(IndexWriter writer, MergeTrigger trigger, boolean newMergesFound)
-            throws IOException {
+  private static class WrappedOneMerge extends MergePolicy.OneMerge {
 
-          while(true) {
-            OneMerge merge = writer.getNextMerge();
-            if (merge == null)
-              break;
-            
-            assertTrue("Wanted a wrapped merge", merge instanceof WrappedOneMerge);
-            
-            
-            writer.merge(merge);
-          }
-          
-        }
-      };
+    final MergePolicy.OneMerge original;
 
-      MergePolicy mp = mergePolicy();
-      assumeFalse("this test cannot tolerate random forceMerges", mp.toString().contains("MockRandomMergePolicy"));
-      mp.setNoCFSRatio(random().nextBoolean() ? 0 : 1);
+    public WrappedOneMerge(MergePolicy.OneMerge original) {
+      super(original.segments);
+      this.original = original;
+    }
 
-      IndexWriterConfig iwc = newIndexWriterConfig(new MockAnalyzer(random()));
-      iwc.setMergeScheduler(mergeScheduler);
-      iwc.setMergePolicy(mp);
+  }
 
-      IndexWriter writer = new IndexWriter(dir, iwc);
-      final int numSegments = TestUtil.nextInt(random(), 20, 40);
-      for (int i = 0; i < numSegments; ++i) {
-        final int numDocs = TestUtil.nextInt(random(), 1, 5);
-        for (int j = 0; j < numDocs; ++j) {
-          writer.addDocument(new Document());
-        }
-        
-        writer.getReader().close();
-        
-        if(i < numSegments-1) {
-          writer.maybeMerge();
-        }
-        
-      }
-      
-      for (int i = 5; i >= 0; --i) {
-        final int segmentCount = writer.getSegmentCount();
-        final int maxNumSegments = i == 0 ? 1 : TestUtil.nextInt(random(), 1, 10);
-        if (VERBOSE) {
-          System.out
-              .println("TEST: now forceMerge(maxNumSegments=" + maxNumSegments + ") vs segmentCount=" + segmentCount);
-        }
-        writer.forceMerge(maxNumSegments);
-        
-      }
-      writer.close();
+  @Test
+  public void testSegmentsAreWrapped() throws IOException {
+    try (final Directory dir = newDirectory()) {
+      // first create random merge specs
+      final MergePolicy.MergeSpecification msM = createRandomMergeSpecification(dir);
+      final MergePolicy.MergeSpecification msF = createRandomMergeSpecification(dir);
+      final MergePolicy.MergeSpecification msD = createRandomMergeSpecification(dir);
+      // secondly, pass them to the predetermined merge policy constructor
+      final MergePolicy originalMP = new PredeterminedMergePolicy(msM, msF, msD);
+      // thirdly wrap the predetermined merge policy
+      final MergePolicy oneMergeWrappingMP = new OneMergeWrappingMergePolicy(
+          originalMP,
+          merge -> new WrappedOneMerge(merge));
+      // finally, ask for merges and check what we got
+      implTestSegmentsAreWrapped(msM, oneMergeWrappingMP.findMerges(null, null, null));
+      implTestSegmentsAreWrapped(msF, oneMergeWrappingMP.findForcedMerges(null, 0, null, null));
+      implTestSegmentsAreWrapped(msD, oneMergeWrappingMP.findForcedDeletesMerges(null, null));
     }
   }
+
+  private static void implTestSegmentsAreWrapped(MergePolicy.MergeSpecification originalMS, MergePolicy.MergeSpecification testMS) {
+    // wrapping does not add or remove merge specs
+    assertEquals((originalMS == null), (testMS == null));
+    if (originalMS == null) return;
+    assertEquals(originalMS.merges.size(), testMS.merges.size());
+    // wrapping does not re-order merge specs
+    for (int ii = 0; ii < originalMS.merges.size(); ++ii) {
+        final MergePolicy.OneMerge originalOM = originalMS.merges.get(ii);
+        final MergePolicy.OneMerge testOM = testMS.merges.get(ii);
+        // wrapping wraps
+        assertTrue(testOM instanceof WrappedOneMerge);
+        final WrappedOneMerge wrappedOM = (WrappedOneMerge)testOM;
+        // and what is wrapped is what was originally passed in
+        assertEquals(originalOM, wrappedOM.original);
+    }
+  }
+
+  private static MergePolicy.MergeSpecification createRandomMergeSpecification(Directory dir) {
+    MergePolicy.MergeSpecification ms;
+    if (0 < random().nextInt(10)) { // ~ 1 in 10 times return null
+      ms = new MergePolicy.MergeSpecification();
+      // append up to 10 (random non-sensical) one merge objects
+      for (int ii = 0; ii < random().nextInt(10); ++ii) {
+        final SegmentInfo si = new SegmentInfo(
+            dir, // dir
+            Version.LATEST, // version
+            TestUtil.randomSimpleString(random()), // name
+            random().nextInt(), // maxDoc
+            random().nextBoolean(), // isCompoundFile
+            null, // codec
+            Collections.emptyMap(), // diagnostics
+            TestUtil.randomSimpleString(// id
+                random(),
+                StringHelper.ID_LENGTH,
+                StringHelper.ID_LENGTH).getBytes(StandardCharsets.US_ASCII),
+            Collections.emptyMap(), // attributes
+            null /* indexSort */);
+        final List<SegmentCommitInfo> segments = new LinkedList<SegmentCommitInfo>();
+        segments.add(new SegmentCommitInfo(si, 0, 0, 0, 0));
+        ms.add(new MergePolicy.OneMerge(segments));
+      }
+    }
+    return null;
+  }
+
 }


### PR DESCRIPTION
* Added class-level OneMergeWrappingMergePolicy javadocs.

* Replaced WrapOneMerge interface with UnaryOperator<OneMerge>.

* Proposes alternative TestOneMergeWrappingMergePolicy unit test.